### PR TITLE
Fix python execution

### DIFF
--- a/Interpret.py
+++ b/Interpret.py
@@ -1,4 +1,4 @@
-#!/bin/bash/python
+#!/usr/bin/env python
 
 file = open("Mediator.txt", "r")
 list = file.readlines()


### PR DESCRIPTION
Your interpreter line for the python script is slightly mistaken, though masked by calling python directly from the bash script. The first line should either have the absolute path of the script interpreter you want, such as /usr/bin/python, which may vary among Linux distributions, or a call to /usr/bin/env (which is supposed to be standardized across distros) with an argument of the interpreter you're using.

Also, this PR adds the execute bit to the python script so it could be launched directly.